### PR TITLE
Fix AWS secret env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ Eliminar comentarios propios
 Comentar publicaciones de otros usuarios.
 
 Dar y quitar likes ❤️.
+
+## ⚙️ Configuración
+
+Para ejecutar la API se requiere un archivo de entorno. Puedes usar el archivo
+`backend/.env.example` como referencia y renombrarlo a `.env` dentro de la
+carpeta `backend`. Asegúrate de definir `AWS_SECRET_ACCESS_KEY` junto con el
+resto de variables necesarias.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,17 @@
+# Example environment variables for the blog API
+
+# Database
+URL_MONGO=mongodb://localhost:27017/blogdb
+DB_NAME=blogdb
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_HOST=localhost
+
+# JWT secret
+SECRET_KEY=your_jwt_secret
+
+# AWS S3 configuration
+AWS_BUCKET_NAME=your_bucket_name
+AWS_BUCKET_REGION=your_bucket_region
+AWS_PUBLIC_KEY=your_public_key
+AWS_SECRET_ACCESS_KEY=your_secret_key

--- a/backend/src/config/settings.js
+++ b/backend/src/config/settings.js
@@ -4,7 +4,7 @@ require('dotenv').config();
 const AWS_BUCKET_NAME = process.env.AWS_BUCKET_NAME;
 const AWS_BUCKET_REGION = process.env.AWS_BUCKET_REGION;
 const AWS_PUBLIC_KEY = process.env.AWS_PUBLIC_KEY;
-const AWS_SECRET_ACCES_KEY = process.env.AWS_SECRET_ACCES_KEY;
+const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
 
 // Data Base Environment Variables
 const DB_NAME = process.env.DB_NAME;
@@ -16,7 +16,7 @@ module.exports = {
     AWS_BUCKET_NAME,
     AWS_BUCKET_REGION,
     AWS_PUBLIC_KEY,
-    AWS_SECRET_ACCES_KEY,
+    AWS_SECRET_ACCESS_KEY,
     DB_NAME,
     DB_USER,
     DB_PASSWORD,

--- a/backend/src/services/s3.js
+++ b/backend/src/services/s3.js
@@ -1,11 +1,11 @@
 const { S3Client, PutObjectCommand, DeleteObjectCommand } = require("@aws-sdk/client-s3");
-const { AWS_BUCKET_NAME, AWS_BUCKET_REGION, AWS_PUBLIC_KEY, AWS_SECRET_ACCES_KEY } = require('../config/settings.js');
+const { AWS_BUCKET_NAME, AWS_BUCKET_REGION, AWS_PUBLIC_KEY, AWS_SECRET_ACCESS_KEY } = require('../config/settings.js');
 
 const s3 = new S3Client({
     region: AWS_BUCKET_REGION,
     credentials: {
         accessKeyId: AWS_PUBLIC_KEY,
-        secretAccessKey: AWS_SECRET_ACCES_KEY,
+        secretAccessKey: AWS_SECRET_ACCESS_KEY,
     },
 });
 


### PR DESCRIPTION
## Summary
- correct AWS secret key env name in backend config and S3 service
- add `.env.example` to document required environment variables
- document env file usage in README

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend/vuetify-project` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688a5716c7148321ad924207bd99f715